### PR TITLE
feat: add GitHub access token support (DAC-484)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,7 @@
     ciceroActions = cicero.lib.callActionsWithExtraArgs rec {
       inherit std lib;
       nixpkgsFlake = "github:NixOS/nixpkgs/${nixpkgs.rev}"; # TODO Get the full URL from Nix somehow
-      #helperFlakeInput = exe: "github:input-output-hk/dapps-certification#dapps-certification-helpers:exe:${exe}";
-      #TODO: replace this with the above once the branch is merged
-      helperFlakeInput = exe: "github:input-output-hk/dapps-certification/feat/private-repo-access#dapps-certification-helpers:exe:${exe}";
+      helperFlakeInput = exe: "github:input-output-hk/dapps-certification#dapps-certification-helpers:exe:${exe}";
     } ./actions;
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,9 @@
     ciceroActions = cicero.lib.callActionsWithExtraArgs rec {
       inherit std lib;
       nixpkgsFlake = "github:NixOS/nixpkgs/${nixpkgs.rev}"; # TODO Get the full URL from Nix somehow
-      helperFlakeInput = exe: "github:input-output-hk/dapps-certification#dapps-certification-helpers:exe:${exe}";
+      #helperFlakeInput = exe: "github:input-output-hk/dapps-certification#dapps-certification-helpers:exe:${exe}";
+      #TODO: replace this with the above once the branch is merged
+      helperFlakeInput = exe: "github:input-output-hk/dapps-certification/feat/private-repo-access#dapps-certification-helpers:exe:${exe}";
     } ./actions;
   };
 }


### PR DESCRIPTION
`dapps-certification` now supports the optional `--gh-access-token` as GitHub Token to access restricted repos.
This is the modification accordingly to [this PR](https://github.com/input-output-hk/dapps-certification/pull/52) 